### PR TITLE
Fixed an issue when destroying a banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,5 +118,6 @@ buildNumber.properties
 # Common working directory
 run/
 build
+bin/
 .gradle
 /*.jar

--- a/src/main/java/net/pl3x/map/banners/listener/BannerListener.java
+++ b/src/main/java/net/pl3x/map/banners/listener/BannerListener.java
@@ -168,10 +168,13 @@ public class BannerListener implements Listener {
         Location loc = banner.getLocation();
         Position pos = new Position(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
 
-        layer.removeBanner(pos);
-
-        // play fancy particles as visualizer
-        particles(banner.getLocation(), Particle.WAX_ON, Sound.ENTITY_ALLAY_ITEM_TAKEN);
+        // check if the banner is displayed to avoid triggering effects if it is not
+        if (layer.hasBanner(pos)) {
+            layer.removeBanner(pos);
+            
+            // play fancy particles as visualizer
+            particles(banner.getLocation(), Particle.WAX_ON, Sound.ENTITY_ALLAY_ITEM_TAKEN);
+        }
     }
 
     protected String getCustomName(org.bukkit.block.Banner banner) {

--- a/src/main/java/net/pl3x/map/banners/listener/BannerListener.java
+++ b/src/main/java/net/pl3x/map/banners/listener/BannerListener.java
@@ -149,7 +149,7 @@ public class BannerListener implements Listener {
         layer.putBanner(new Banner(pos, icon, getCustomName(banner)));
 
         // play fancy particles as visualizer
-        particles(banner.getLocation(), Particle.VILLAGER_HAPPY, Sound.ENTITY_PLAYER_LEVELUP);
+        particles(banner.getLocation(), Particle.VILLAGER_HAPPY, Sound.ENTITY_ALLAY_ITEM_GIVEN);
     }
 
     protected void tryRemoveBanner(@NotNull BlockState state) {
@@ -171,7 +171,7 @@ public class BannerListener implements Listener {
         layer.removeBanner(pos);
 
         // play fancy particles as visualizer
-        particles(banner.getLocation(), Particle.WAX_ON, Sound.ENTITY_GHAST_HURT);
+        particles(banner.getLocation(), Particle.WAX_ON, Sound.ENTITY_ALLAY_ITEM_TAKEN);
     }
 
     protected String getCustomName(org.bukkit.block.Banner banner) {

--- a/src/main/java/net/pl3x/map/banners/listener/BannerListener.java
+++ b/src/main/java/net/pl3x/map/banners/listener/BannerListener.java
@@ -149,7 +149,7 @@ public class BannerListener implements Listener {
         layer.putBanner(new Banner(pos, icon, getCustomName(banner)));
 
         // play fancy particles as visualizer
-        particles(banner.getLocation(), Particle.VILLAGER_HAPPY, Sound.ENTITY_ALLAY_ITEM_GIVEN);
+        particles(banner.getLocation(), Particle.VILLAGER_HAPPY, Sound.ENTITY_PLAYER_LEVELUP);
     }
 
     protected void tryRemoveBanner(@NotNull BlockState state) {
@@ -173,7 +173,7 @@ public class BannerListener implements Listener {
             layer.removeBanner(pos);
             
             // play fancy particles as visualizer
-            particles(banner.getLocation(), Particle.WAX_ON, Sound.ENTITY_ALLAY_ITEM_TAKEN);
+            particles(banner.getLocation(), Particle.WAX_ON, Sound.ENTITY_GHAST_HURT);
         }
     }
 

--- a/src/main/java/net/pl3x/map/banners/markers/BannersLayer.java
+++ b/src/main/java/net/pl3x/map/banners/markers/BannersLayer.java
@@ -131,6 +131,10 @@ public class BannersLayer extends WorldLayer {
         saveData();
     }
 
+    public boolean hasBanner(@NotNull Position pos) {
+        return this.markers.containsKey(pos) || this.banners.containsKey(pos);
+    }
+
     private void loadData() {
         if (!Files.exists(this.dataFile)) {
             return;


### PR DESCRIPTION
When breaking a banner, the "remove banner" effect is triggered even if the banner is not in the banner layer.
This PR fixes this bug by adding a check before triggering the effect

----
### Old PR:
This is a PR suggestion for changing the sounds when placing or removing a banner from the map.
Currently, the place sound is `ENTITY_PLAYER_LEVELUP`, which is not annoying, however, the breaking sound is `ENTITY_GHAST_HURT` which is a very annoying sound, especially when you don't expect to hear it.

This PR replaces it with `ENTITY_ALLAY_ITEM_TAKEN`, and also replaces the placing sound with `ENTITY_ALLAY_ITEM_GIVEN` for consistency.

Also fixed a bug where breaking a banner ingame was triggering the effects even if the banner has not been added to the map.